### PR TITLE
Don't transform Fragment to ReactFragment.

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -58,7 +58,6 @@ const QualifiedReactTypeNameMap = {
   Child: "ReactChild",
   Children: "ReactChildren",
   Element: "ReactElement",
-  Fragment: "ReactFragment",
   Portal: "ReactPortal",
   NodeArray: "ReactNodeArray",
 

--- a/test/fixtures/convert/react-utility-types/Fragment_import/flow.js
+++ b/test/fixtures/convert/react-utility-types/Fragment_import/flow.js
@@ -1,0 +1,5 @@
+import { Fragment } from "react";
+
+const TwoDivs = () => <Fragment><div>Hello World</div><div>It's a great day for TS!</div></Fragment>;
+
+export default TwoDivs;

--- a/test/fixtures/convert/react-utility-types/Fragment_import/ts.js
+++ b/test/fixtures/convert/react-utility-types/Fragment_import/ts.js
@@ -1,0 +1,5 @@
+import { Fragment } from "react";
+
+const TwoDivs = () => <Fragment><div>Hello World</div><div>It's a great day for TS!</div></Fragment>;
+
+export default TwoDivs;

--- a/test/fixtures/convert/react/basic-types-different/flow.js
+++ b/test/fixtures/convert/react/basic-types-different/flow.js
@@ -4,7 +4,6 @@ let node: React.Node;
 let text: React.Text;
 let child: React.Child;
 let children: React.Children;
-let fragment: React.Fragment;
 let portal: React.Portal;
 let nodeArray: React.NodeArray;
 let element: React.Element;

--- a/test/fixtures/convert/react/basic-types-different/ts.js
+++ b/test/fixtures/convert/react/basic-types-different/ts.js
@@ -4,7 +4,6 @@ let node: React.ReactNode;
 let text: React.ReactText;
 let child: React.ReactChild;
 let children: React.ReactChildren;
-let fragment: React.ReactFragment;
 let portal: React.ReactPortal;
 let nodeArray: React.ReactNodeArray;
 let element: React.ReactElement;


### PR DESCRIPTION
There doesn't actually appear to be a Fragment type in Flow anymore, so there's minimal risk with removing this that someone was actually using `Fragment` as a type, not a value.