### PR TITLE
Throw error in function type definition if rest parameter has no type annotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@babel/core": "^7.6.0",
     "@babel/generator": "npm:@khell/babel-generator@^7.6.0",
-    "@babel/parser": "^7.5.5",
+    "@babel/parser": "^7.6.0",
     "@babel/traverse": "npm:@khell/babel-traverse@^7.6.0",
     "@babel/types": "npm:@khell/babel-types@^7.6.4",
     "colors": "^1.3.3",

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -407,6 +407,16 @@ const transform: Visitor<VisitorState> = {
 
       const restNode: t.Node | null = rest as any;
       if (restNode && restNode.type === "Identifier") {
+        // Check if the argument actually has a name
+        // https://github.com/khell/flow-to-ts/issues/5
+        if (!restNode.name) {
+          throw new Error(
+            `Uncaught syntax error from parser on line ${restNode.loc &&
+              restNode.loc
+                .start}: Encountered in function type definition a rest parameter without a name.`
+          );
+        }
+
         const restElement: t.RestElement = {
           type: "RestElement",
           argument: restNode,
@@ -454,18 +464,13 @@ const transform: Visitor<VisitorState> = {
       // TypeScript AST simplifies these annotations in a single TSFunctionType
       const { name, optional, typeAnnotation } = path.node;
       const identifier: t.Identifier = {
+        ...BaseNodeDefaultSpreadTypes,
         type: "Identifier",
         name: name ? name.name : "",
         optional,
         typeAnnotation: t.tsTypeAnnotation(toTSType(typeAnnotation)),
         decorators: [],
-        leadingComments: null,
-        innerComments: null,
-        trailingComments: null,
-        start: null,
-        end: null,
-        loc: null,
-        newlines: undefined
+        loc: name && name.loc
       };
       // TODO: patch @babel/types - t.identifier omits typeAnnotation
       // const identifier = t.identifier(name.name, decorators, optional, t.tsTypeAnnotation(typeAnnotation));

--- a/test/fixtures/convert/function-types/rest02/flow.js
+++ b/test/fixtures/convert/function-types/rest02/flow.js
@@ -1,0 +1,3 @@
+// The rest spread parameter is untyped which is invalid syntax
+// This test case is expected to fail
+type Foo = (...rest) => string | boolean[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,7 +97,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.5.5":
+"@babel/parser@^7.1.0", "@babel/parser@^7.4.3":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
   integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==


### PR DESCRIPTION
The rest parameter's argument name is actually parsed as the type annotation, leaving the argument name empty (and the type annotation most likely not a valid type). This is a parser issue, so it should be fixed there.